### PR TITLE
use before_action/after_action instead of before_filter/after_filter

### DIFF
--- a/lib/userstamp.rb
+++ b/lib/userstamp.rb
@@ -14,8 +14,8 @@ module Ddb
     module Userstamp
       def self.included(base) # :nodoc:
         base.send           :include, InstanceMethods
-        base.before_filter  :set_stamper
-        base.after_filter   :reset_stamper
+        base.before_action  :set_stamper
+        base.after_action   :reset_stamper
       end
 
       module InstanceMethods

--- a/lib/userstamp/version.rb
+++ b/lib/userstamp/version.rb
@@ -1,3 +1,3 @@
 module Userstamp
-  VERSION = "2.0.2"
+  VERSION = "2.1.0"
 end

--- a/userstamp.gemspec
+++ b/userstamp.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
+  s.add_dependency('rails', '>= 4.0')
 
   # specify any dependencies here; for example:
   # s.add_development_dependency "rspec"


### PR DESCRIPTION
Using before_action/after_action instead of before_filter/after_filter, before_filter/after_filter got deprecated in Rails 5.1

- [ ] @johnny-lai 
- [ ] @saghaulor 