### PR TITLE
Include _id in migration helper

### DIFF
--- a/lib/userstamp/migration_helper.rb
+++ b/lib/userstamp/migration_helper.rb
@@ -6,10 +6,15 @@ module Ddb
       end
 
       module InstanceMethods
-        def userstamps(include_deleted_by = false)
-          column(Ddb::Userstamp.compatibility_mode ? :created_by : :creator_id, :integer)
-          column(Ddb::Userstamp.compatibility_mode ? :updated_by : :updater_id, :integer)
-          column(Ddb::Userstamp.compatibility_mode ? :deleted_by : :deleter_id, :integer) if include_deleted_by
+        def userstamps(options = {})
+          # add backwards compatibility support
+          options = {include_deleted_by: options} if (options === true || options === false)
+
+          append_id_suffix = options[:include_id] ? '_id' : ''
+
+          column(Ddb::Userstamp.compatibility_mode ? "created_by#{append_id_suffix}".to_sym : :creator_id, :integer)
+          column(Ddb::Userstamp.compatibility_mode ? "updated_by#{append_id_suffix}".to_sym : :updater_id, :integer)
+          column(Ddb::Userstamp.compatibility_mode ? "deleted_by#{append_id_suffix}".to_sym : :deleter_id, :integer) if options[:include_deleted_by]
         end
       end
     end


### PR DESCRIPTION
- [x] @aergonaut 
- [x] @johnny-lai 

Chris mentioned upcoming upgrade problems. We can help reduce the load by adding `_id` in the migration helper now.